### PR TITLE
优化recorder实例的初始化过程

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function Recorders(stream, config) {
 
     this.AudioCtx = this._gotStream(stream)
     this.RECWorker = this._importWorker()
+    this._init(config)
 }
 
 Recorders.prototype.onStreamProcessor = null
@@ -32,10 +33,9 @@ Recorders.prototype._importWorker = function() {
     return new Worker(window.URL.createObjectURL(blob))
 }
 
-Recorders.prototype.startRecord = function(config = {}) {
+Recorders.prototype._init = function(config = {}) {
     const recorder = this.AudioCtx.context.createScriptProcessor(1024, 1, 1)
     this.AudioCtx.connect(recorder)
-    recorder.connect(this.AudioCtx.context.destination)
 
     this.RECWorker.postMessage({
         command: 'init',
@@ -82,6 +82,10 @@ Recorders.prototype.startRecord = function(config = {}) {
 
 
     this.Recorder = recorder
+}
+
+Recorders.prototype.startRecord = function() {
+    this.Recorder.connect(this.AudioCtx.context.destination)
 }
 
 Recorders.prototype.stopRecord = function() {


### PR DESCRIPTION
目前，recorder实例是在调用startRecord的时候进行的初始化，这样有两个潜在的问题：
1. 每次调用startRecord都要重新执行初始化操作
2. 如果没有调用startRecord，而调用stopRecord，会造成对象undefined错误

这次commit主要是解决上述两个潜在的问题而提交的。