### PR TITLE
remove this.analyserNode = null;

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ Recorders.prototype.stopRecord = function() {
   if (this.config.exportAudio && this.config.exportAudio === 'wav') {
     this.RECWorker.postMessage({command: 'exportAudio', type: 'wav'})
   }
-  this.analyserNode = null;
+  
   this.Recorder && this.Recorder.disconnect()
 }
 


### PR DESCRIPTION
fix bug  解决多次startRecord analyserNode 获取失败问题